### PR TITLE
fix(library.js): change nulls in settings to empty strings

### DIFF
--- a/library.js
+++ b/library.js
@@ -20,13 +20,13 @@
 		pluginSettingsURL: '/admin/plugins/fusionauth-oidc',
 		pluginSettings: new Settings('fusionauth-oidc', '1.0.0', {
 			// Default settings
-			clientId: null,
-			clientSecret: null,
+			clientId: '',
+			clientSecret: '',
 			emailClaim: 'email',
-			discoveryBaseURL: null,
-			authorizationEndpoint: null,
-			tokenEndpoint: null,
-			userInfoEndpoint: null,
+			discoveryBaseURL: '',
+			authorizationEndpoint: '',
+			tokenEndpoint: '',
+			userInfoEndpoint: '',
 		}, false, false),
 	};
 


### PR DESCRIPTION
- The initial settings seem to be passed to NodeBB at the very
beginning, these settings are all null and are expected to be
filled in at the Plugins -> OpenID Connect panel
- NodeBB v1.19.1 complains that the settings are null and refuses
to start up; and the settings can never be filled in
- We replace the nulls with empty strings; this allows NodeBB
to start and then the OpenID Connect panel can be filled out

- [This issue](https://github.com/NodeBB/NodeBB/issues/9618) from the NodeBB repo helped to get to the bottom of the problem
- The fix works on NodeBB 1.19.1. Was able to add an OIDC configuration and login.
- **I'm not sure if empty strings are the correct or secure approach, please replace it with a better placeholder if possible**